### PR TITLE
Test with the lowest possible dependencies as well

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest, macOS-latest]
         php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
-        composer-flags: ['--prefer-stable', '--prefer-lowest', '']
+        composer-flags: ['--prefer-lowest', '']
     name: PHP ${{ matrix.php-versions }} test on ${{ matrix.operating-system }}
     steps:
     - name: Checkout

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest, macOS-latest]
         php-versions: ['7.0', '7.1', '7.2', '7.3']
+        composer-flags: ['--prefer-stable', '--prefer-lowest', '']
     name: PHP ${{ matrix.php-versions }} test on ${{ matrix.operating-system }}
     steps:
     - name: Checkout
@@ -22,6 +23,6 @@ jobs:
         extension-csv: mbstring,dom
         coverage: xdebug
     - name: Install dependencies
-      run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+      run: composer update --no-progress --no-suggest --prefer-dist --optimize-autoloader ${{ matrix.composer-flags }}
     - name: Run test suite
       run: vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7|^6",
         "mockery/mockery": "^1.2",
-        "orchestra/testbench": "^3.4"
+        "orchestra/testbench": "^3.4.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "ramsey/uuid": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6",
+        "phpunit/phpunit": "^5.7|^6",
         "mockery/mockery": "^1.2",
         "orchestra/testbench": "^3.4"
     },


### PR DESCRIPTION
We'll introduce `--prefer-lowest` as a Composer flag to run the tests against the lowest _possible_ versions of all dependencies. This ensures maximum compatibility across as many versions as possible.

It does, however, triple the amount of tests that are run per workflow run. 