### PR TITLE
No longer use deprecated 'extension-csv' variable

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -19,7 +19,7 @@ jobs:
       uses: shivammathur/setup-php@master
       with:
         php-version: ${{ matrix.php-versions }}
-        extension: mbstring, dom
+        extensions: mbstring, dom
         coverage: xdebug
     - name: Install dependencies
       run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -19,7 +19,7 @@ jobs:
       uses: shivammathur/setup-php@master
       with:
         php-version: ${{ matrix.php-versions }}
-        extension-csv: mbstring,dom
+        extension: mbstring, dom
         coverage: xdebug
     - name: Install dependencies
       run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader


### PR DESCRIPTION
The `extension-csv` variable for `shivammathur/setup-php` is deprecated, we'll use `extensions` instead: https://github.com/shivammathur/setup-php/blob/51c7527bd880153c913674f27a988b16294451ae/action.yml#L24-L27